### PR TITLE
Potential fix for code scanning alert no. 105: Flask app is run in debug mode

### DIFF
--- a/api/newsletter/subscribe.py
+++ b/api/newsletter/subscribe.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, jsonify
+import os
 
 # subscribe.py
 
@@ -22,4 +23,5 @@ def subscribe():
     return jsonify({'message': f'Successfully subscribed {email} to the newsletter!'}), 200
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/Nonovan/webapp/security/code-scanning/105](https://github.com/Nonovan/webapp/security/code-scanning/105)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can set the debug mode to `True` during development and `False` during production.

1. Import the `os` module to access environment variables.
2. Modify the `app.run` call to set the `debug` parameter based on an environment variable.
3. Set a default value for the environment variable to ensure the application does not run in debug mode by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
